### PR TITLE
Fix styling issue with sliders

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -49,12 +49,9 @@
   width: 50%;
 }
 
-
 .likertScale.layout--stacked {
-  align-items: center;
   margin-bottom: 30px;
 }
-
 
 .likertLegend {
   font-weight: bold;

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -13,7 +13,7 @@ function Slider({ skill, index, descriptors }) {
       { value: 5, text: descriptors[4] },
     ],
     layout: "stacked",
-    style: { "align-items": "center" },
+    style: { alignItems: "center" },
   };
   return (
     <RadarConsumer>

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -13,6 +13,7 @@ function Slider({ skill, index, descriptors }) {
       { value: 5, text: descriptors[4] },
     ],
     layout: "stacked",
+    style: { "align-items": "center" },
   };
   return (
     <RadarConsumer>


### PR DESCRIPTION
In **production** the custom styling gets overwritten by the default styling see:

![Screenshot 2023-03-01 at 09 03 11](https://user-images.githubusercontent.com/1273965/222094697-0f4a5e68-a368-4aef-8bf3-4ad4383c4e80.png)
![Screenshot 2023-03-01 at 09 03 51](https://user-images.githubusercontent.com/1273965/222094703-3324c093-59c2-4853-af0f-69833e94ef70.png)

To avoid using `!important`, move the styling directly to the component instead.